### PR TITLE
Add dismiss drag progress property

### DIFF
--- a/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
+++ b/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import coil.annotation.ExperimentalCoilApi
@@ -24,6 +25,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.mxalbert.zoomable.Zoomable
 import com.mxalbert.zoomable.rememberZoomableState
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -68,6 +70,7 @@ private fun Sample(onDismiss: () -> Unit) {
                         modifier = Modifier
                             .aspectRatio(size.width / size.height)
                             .fillMaxSize()
+                            .graphicsLayer { alpha = 1 - abs(state.dismissDragOffset) }
                     )
                 }
             }
@@ -81,6 +84,10 @@ private fun Sample(onDismiss: () -> Unit) {
                 Checkbox(checked = enabled, onCheckedChange = { enabled = it })
                 Text(text = "Enable")
                 Spacer(modifier = Modifier.weight(1f))
+
+                Text(text = abs(state.dismissDragOffset).toString())
+                Spacer(modifier = Modifier.weight(1f))
+
                 Button(onClick = {
                     scope.launch {
                         state.animateTranslateTo(Offset.Zero)

--- a/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
+++ b/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import coil.annotation.ExperimentalCoilApi
@@ -25,7 +24,6 @@ import com.google.accompanist.pager.HorizontalPager
 import com.mxalbert.zoomable.Zoomable
 import com.mxalbert.zoomable.rememberZoomableState
 import kotlinx.coroutines.launch
-import kotlin.math.abs
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -70,7 +68,6 @@ private fun Sample(onDismiss: () -> Unit) {
                         modifier = Modifier
                             .aspectRatio(size.width / size.height)
                             .fillMaxSize()
-                            .graphicsLayer { alpha = 1 - abs(state.dismissDragOffset) }
                     )
                 }
             }
@@ -84,10 +81,6 @@ private fun Sample(onDismiss: () -> Unit) {
                 Checkbox(checked = enabled, onCheckedChange = { enabled = it })
                 Text(text = "Enable")
                 Spacer(modifier = Modifier.weight(1f))
-
-                Text(text = abs(state.dismissDragOffset).toString())
-                Spacer(modifier = Modifier.weight(1f))
-
                 Button(onClick = {
                     scope.launch {
                         state.animateTranslateTo(Offset.Zero)

--- a/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
@@ -114,6 +114,18 @@ class ZoomableState(
             }
         }
 
+    /**
+     * Current dismiss drag offset of [Zoomable].
+     *
+     * Can be used to animate translucency of Composable via
+     * [androidx.compose.ui.graphics.GraphicsLayerScope.alpha] property in
+     * the [androidx.compose.ui.graphics.graphicsLayer].
+     */
+    val dismissDragOffset: Float by derivedStateOf {
+        val maxOffset = childSize.height
+        (dismissDragAbsoluteOffsetY / maxOffset).coerceIn(-1f, 1f)
+    }
+
     internal val shouldDismiss: Boolean
         get() = abs(dismissDragAbsoluteOffsetY) > size.height * DismissDragThreshold
 


### PR DESCRIPTION
I think it would be nice, if there was an API that exposes current drag offset state. So I've implemented this.

One of the use cases for that is to animate translucency of a Composable using [alpha](https://developer.android.com/reference/kotlin/androidx/compose/ui/graphics/GraphicsLayerScope#alpha()). I've added an example of this to the sample.

https://user-images.githubusercontent.com/44653764/146892278-5b566704-7351-483f-a433-5d73ae2161b3.mp4


