### PR TITLE
Allow pager to consume drag events at bounds

### DIFF
--- a/zoomable/src/main/java/com/mxalbert/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/Zoomable.kt
@@ -186,7 +186,7 @@ private suspend fun PointerInputScope.detectDragGestures(
                 val drag = if (state.isZooming) {
                     if (startDragImmediately()) down else {
                         awaitTouchSlopOrCancellation(down.id) { change, over ->
-                            if (state.isMaxX(change)) {
+                            if (state.isMaxX(change.positionChange())) {
                                 return@awaitTouchSlopOrCancellation
                             }
                             change.consumePositionChange()

--- a/zoomable/src/main/java/com/mxalbert/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/Zoomable.kt
@@ -186,6 +186,9 @@ private suspend fun PointerInputScope.detectDragGestures(
                 val drag = if (state.isZooming) {
                     if (startDragImmediately()) down else {
                         awaitTouchSlopOrCancellation(down.id) { change, over ->
+                            if (state.isMaxX(change)) {
+                                return@awaitTouchSlopOrCancellation
+                            }
                             change.consumePositionChange()
                             overSlop = over
                         }

--- a/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
@@ -183,10 +183,16 @@ class ZoomableState(
         private set
 
     internal fun isMaxX(changeOffset: Offset): Boolean {
-        if (!sameDirection(changeOffset.x, translationX)) { return false }
+        val difference: Int = (abs(translationX) - boundOffset.x.coerceAtLeast(0)).roundToInt()
 
-        val diff = abs(translationX) - boundOffset.x.coerceAtLeast(0)
-        return  diff >= -1 && diff <= 1
+        val isDragSameDirection = sameDirection(changeOffset.x, translationX);
+        val horizontalDragAffectsBound = translationX.roundToInt() != 0
+
+        if ((horizontalDragAffectsBound && !isDragSameDirection) || difference != 0) {
+            return false
+        }
+
+        return  difference >= -1 && difference <= 1
     }
 
     private fun updateBounds() {

--- a/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
@@ -10,8 +10,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
 import androidx.compose.ui.geometry.lerp
-import androidx.compose.ui.input.pointer.PointerInputChange
-import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -184,8 +182,8 @@ class ZoomableState(
     internal var isGestureInProgress: Boolean by mutableStateOf(false)
         private set
 
-    internal fun isMaxX(change: PointerInputChange): Boolean {
-        if (!sameDirection(change.positionChange().x, translationX)) { return false }
+    internal fun isMaxX(changeOffset: Offset): Boolean {
+        if (!sameDirection(changeOffset.x, translationX)) { return false }
 
         val diff = abs(translationX) - boundOffset.x.coerceAtLeast(0)
         return  diff >= -1 && diff <= 1

--- a/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/ZoomableState.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
 import androidx.compose.ui.geometry.lerp
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -181,6 +183,13 @@ class ZoomableState(
     private var flingJob: Job? = null
     internal var isGestureInProgress: Boolean by mutableStateOf(false)
         private set
+
+    internal fun isMaxX(change: PointerInputChange): Boolean {
+        if (!sameDirection(change.positionChange().x, translationX)) { return false }
+
+        val diff = abs(translationX) - boundOffset.x.coerceAtLeast(0)
+        return  diff >= -1 && diff <= 1
+    }
 
     private fun updateBounds() {
         val offsetX = childSize.width * scale - size.width
@@ -403,3 +412,9 @@ class OverZoomConfig(
 
 internal val OverZoomConfig.range: ClosedFloatingPointRange<Float>
     get() = minSnapScale..maxSnapScale
+
+private fun sameDirection(a: Float, b: Float): Boolean {
+    val bitA = sign(a).toInt()
+    val bitB = sign(b).toInt()
+    return bitA xor bitB == 0
+}


### PR DESCRIPTION
This change returns early from the drag event when a zoomed image is at its maximum X-axis bounds. This ensures that the drag event is not consumed and is available to parent components like a view pager.

The isMaxX function ensures that the current drag event is in the same direction as the current ZoomableState translationX. If the bounds are within one pixel then the isMaxX function returns true.

Edits and discussion are welcome.

The following demo app can be found at https://github.com/jocmp/HorizontalZoomable

## Before
https://user-images.githubusercontent.com/9521010/148670875-6cc4180c-63ec-46d7-a3a4-37fd5e1ccefa.mp4

## After

https://user-images.githubusercontent.com/9521010/148670885-6f2dcf21-e16a-4ff8-9d2f-8298740b9f89.mp4





