### PR TITLE
Add onTap parameter to Zoomable

### DIFF
--- a/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
+++ b/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
@@ -29,7 +29,6 @@ import com.mxalbert.zoomable.Zoomable
 import com.mxalbert.zoomable.rememberZoomableState
 import kotlinx.coroutines.launch
 
-@ExperimentalAnimationApi
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,8 +47,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@ExperimentalAnimationApi
-@OptIn(ExperimentalPagerApi::class, ExperimentalCoilApi::class)
+@OptIn(ExperimentalPagerApi::class, ExperimentalCoilApi::class, ExperimentalAnimationApi::class)
 @Composable
 private fun Sample(onDismiss: () -> Unit) {
     HorizontalPager(count = images.size) { index ->
@@ -87,10 +85,9 @@ private fun Sample(onDismiss: () -> Unit) {
 
             AnimatedVisibility(
                 visible = isOverlayVisible,
-                enter = slideInVertically() + fadeIn(),
-                exit = slideOutVertically() + fadeOut(),
+                enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+                exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut(),
             ) {
-
                 val scope = rememberCoroutineScope()
                 Row(
                     modifier = Modifier

--- a/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
+++ b/sample/src/main/java/com/mxalbert/zoomable/sample/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.selection.toggleable
@@ -28,6 +29,7 @@ import com.mxalbert.zoomable.Zoomable
 import com.mxalbert.zoomable.rememberZoomableState
 import kotlinx.coroutines.launch
 
+@ExperimentalAnimationApi
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,12 +48,14 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@ExperimentalAnimationApi
 @OptIn(ExperimentalPagerApi::class, ExperimentalCoilApi::class)
 @Composable
 private fun Sample(onDismiss: () -> Unit) {
     HorizontalPager(count = images.size) { index ->
         var enabled by remember { mutableStateOf(true) }
         var overZoom by remember { mutableStateOf(false) }
+        var isOverlayVisible by remember { mutableStateOf(true) }
         val state = rememberZoomableState(
             minScale = if (overZoom) 0.5f else 1f,
             maxScale = if (overZoom) 6f else 4f,
@@ -61,6 +65,7 @@ private fun Sample(onDismiss: () -> Unit) {
             Zoomable(
                 state = state,
                 enabled = enabled,
+                onTap = { isOverlayVisible = !isOverlayVisible },
                 dismissGestureEnabled = true,
                 onDismiss = {
                     onDismiss()
@@ -79,52 +84,60 @@ private fun Sample(onDismiss: () -> Unit) {
                     )
                 }
             }
-            val scope = rememberCoroutineScope()
-            Row(
-                modifier = Modifier
-                    .statusBarsPadding()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
+
+            AnimatedVisibility(
+                visible = isOverlayVisible,
+                enter = slideInVertically() + fadeIn(),
+                exit = slideOutVertically() + fadeOut(),
             ) {
-                Column {
-                    Row(
-                        modifier = Modifier.toggleable(
-                            value = enabled,
-                            role = Role.Switch,
-                            onValueChange = { enabled = it }
-                        ),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Checkbox(
-                            checked = enabled,
-                            onCheckedChange = null,
-                            modifier = Modifier.padding(2.dp)
-                        )
-                        Text(text = "Enable", modifier = Modifier.padding(2.dp))
+
+                val scope = rememberCoroutineScope()
+                Row(
+                    modifier = Modifier
+                        .statusBarsPadding()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column {
+                        Row(
+                            modifier = Modifier.toggleable(
+                                value = enabled,
+                                role = Role.Switch,
+                                onValueChange = { enabled = it }
+                            ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = enabled,
+                                onCheckedChange = null,
+                                modifier = Modifier.padding(2.dp)
+                            )
+                            Text(text = "Enable", modifier = Modifier.padding(2.dp))
+                        }
+                        Row(
+                            modifier = Modifier.toggleable(
+                                value = overZoom,
+                                role = Role.Switch,
+                                onValueChange = { overZoom = it }
+                            ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = overZoom,
+                                onCheckedChange = null,
+                                modifier = Modifier.padding(2.dp)
+                            )
+                            Text(text = "Enable over-zoom", modifier = Modifier.padding(2.dp))
+                        }
                     }
-                    Row(
-                        modifier = Modifier.toggleable(
-                            value = overZoom,
-                            role = Role.Switch,
-                            onValueChange = { overZoom = it }
-                        ),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Checkbox(
-                            checked = overZoom,
-                            onCheckedChange = null,
-                            modifier = Modifier.padding(2.dp)
-                        )
-                        Text(text = "Enable over-zoom", modifier = Modifier.padding(2.dp))
+                    Spacer(modifier = Modifier.weight(1f))
+                    Button(onClick = {
+                        scope.launch {
+                            state.animateTranslateTo(Offset.Zero)
+                        }
+                    }) {
+                        Text(text = "Center")
                     }
-                }
-                Spacer(modifier = Modifier.weight(1f))
-                Button(onClick = {
-                    scope.launch {
-                        state.animateTranslateTo(Offset.Zero)
-                    }
-                }) {
-                    Text(text = "Center")
                 }
             }
         }

--- a/zoomable/src/main/java/com/mxalbert/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/com/mxalbert/zoomable/Zoomable.kt
@@ -25,6 +25,7 @@ import kotlin.math.roundToInt
  * @param modifier The modifier to apply to this layout.
  * @param state The state object to be used to control or observe the state.
  * @param enabled Controls the enabled state. When false, all gestures will be ignored.
+ * @param onTap Will be called when a single tap is detected.
  * @param dismissGestureEnabled Whether to enable dismiss gesture detection.
  * @param onDismiss Will be called when dismiss gesture is detected. Should return a boolean
  * indicating whether the dismiss request is handled.
@@ -35,6 +36,7 @@ fun Zoomable(
     modifier: Modifier = Modifier,
     state: ZoomableState = rememberZoomableState(),
     enabled: Boolean = true,
+    onTap: ((Offset) -> Unit)? = null,
     dismissGestureEnabled: Boolean = false,
     onDismiss: () -> Boolean = { false },
     content: @Composable () -> Unit
@@ -53,6 +55,7 @@ fun Zoomable(
         Modifier.pointerInput(state) {
             detectZoomableGestures(
                 state = state,
+                onTap = onTap,
                 dismissGestureEnabled = dismissGestureEnabledState,
                 onDismiss = onDismiss
             )
@@ -91,11 +94,13 @@ fun Zoomable(
 
 internal suspend fun PointerInputScope.detectZoomableGestures(
     state: ZoomableState,
+    onTap: ((Offset) -> Unit)?,
     dismissGestureEnabled: State<Boolean>,
     onDismiss: () -> Boolean
 ): Unit = coroutineScope {
     launch {
         detectTapGestures(
+            onTap = onTap,
             onDoubleTap = { offset ->
                 launch {
                     val isZooming = state.isZooming

--- a/zoomable/src/test/java/com/mxalbert/zoomable/SuspendingGestureTestUtil.kt
+++ b/zoomable/src/test/java/com/mxalbert/zoomable/SuspendingGestureTestUtil.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.materialize
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,8 +41,9 @@ import kotlin.coroutines.coroutineContext
 internal class SuspendingGestureTestUtil(
     val width: Int = 10,
     val height: Int = 10,
+    private val viewConfiguration: ViewConfiguration = TestViewConfiguration(),
     private val gestureDetector: suspend PointerInputScope.() -> Unit,
-) {
+) : ViewConfiguration by viewConfiguration {
     private var nextPointerId = 0L
     private val activePointers = mutableMapOf<PointerId, PointerInputChange>()
     private var pointerInputFilter: PointerInputFilter? = null
@@ -80,7 +82,7 @@ internal class SuspendingGestureTestUtil(
             compose(recomposer) {
                 CompositionLocalProvider(
                     LocalDensity provides Density(1f),
-                    LocalViewConfiguration provides TestViewConfiguration()
+                    LocalViewConfiguration provides viewConfiguration
                 ) {
                     pointerInputFilter = currentComposer
                         .materialize(Modifier.pointerInput(Unit, gestureDetector)) as

--- a/zoomable/src/test/java/com/mxalbert/zoomable/ZoomableTest.kt
+++ b/zoomable/src/test/java/com/mxalbert/zoomable/ZoomableTest.kt
@@ -305,7 +305,7 @@ class ZoomableTest {
         SuspendingGestureTestUtil(width = size.width, height = size.height) {
             detectZoomableGestures(
                 state = scope.state,
-                onTap = {},
+                onTap = null,
                 dismissGestureEnabled = scope.dismissGestureEnabled
             ) {
                 scope.dismissed = true

--- a/zoomable/src/test/java/com/mxalbert/zoomable/ZoomableTest.kt
+++ b/zoomable/src/test/java/com/mxalbert/zoomable/ZoomableTest.kt
@@ -303,7 +303,11 @@ class ZoomableTest {
             dismissed = false
         )
         SuspendingGestureTestUtil(width = size.width, height = size.height) {
-            detectZoomableGestures(scope.state, scope.dismissGestureEnabled) {
+            detectZoomableGestures(
+                state = scope.state,
+                onTap = {},
+                dismissGestureEnabled = scope.dismissGestureEnabled
+            ) {
                 scope.dismissed = true
                 false
             }

--- a/zoomable/src/test/java/com/mxalbert/zoomable/ZoomableTest.kt
+++ b/zoomable/src/test/java/com/mxalbert/zoomable/ZoomableTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.input.pointer.anyChangeConsumed
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toSize
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.delay
 import org.junit.Test
 
 @Suppress("TestFunctionName")
@@ -36,6 +37,17 @@ class ZoomableTest {
         assertThat(state.scale).isEqualTo(2f)
         assertThat(state.translationX).isEqualTo(100f)
         assertThat(state.translationY).isEqualTo(100f)
+    }
+
+    @Test
+    fun `Single tap`() {
+        testTapAndDrag { scope ->
+            with(scope) {
+                down().up()
+                delay(doubleTapTimeoutMillis)
+                assertThat(tapped).isTrue()
+            }
+        }
     }
 
     @Test
@@ -299,13 +311,12 @@ class ZoomableTest {
                 this.childSize = size.toSize()
             },
             size = size,
-            dismissGestureEnabled = mutableStateOf(false),
-            dismissed = false
+            dismissGestureEnabled = mutableStateOf(false)
         )
         SuspendingGestureTestUtil(width = size.width, height = size.height) {
             detectZoomableGestures(
                 state = scope.state,
-                onTap = null,
+                onTap = { scope.tapped = true },
                 dismissGestureEnabled = scope.dismissGestureEnabled
             ) {
                 scope.dismissed = true
@@ -319,8 +330,10 @@ class ZoomableTest {
     private class TestTapAndDragScope(
         val state: ZoomableState,
         val size: IntSize,
-        val dismissGestureEnabled: MutableState<Boolean>,
-        var dismissed: Boolean
-    )
+        val dismissGestureEnabled: MutableState<Boolean>
+    ) {
+        var tapped: Boolean = false
+        var dismissed: Boolean = false
+    }
 
 }


### PR DESCRIPTION
Goal was to show and hide an overlay by tapping on a zoomable image. Therefor I adapted also the sample to have a look and feel of the change and use case. 
