### PR TITLE
Support independent versioning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ kotlin = "1.6.10"
 coroutines = "1.6.0"
 compose-jetbrains = "1.1.1"
 compose-jetpack = "1.1.1"
+compose-material = "1.1.1"
+compose-foundation = "1.1.1"
+compose-ui = "1.1.1"
 androidx-activity = "1.4.0"
 accompanist = "0.23.1"
 coil = "2.1.0"
@@ -26,12 +29,12 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 compose-runtime-jetbrains = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-jetbrains" }
 compose-runtime-jetpack = { module = "androidx.compose.runtime:runtime", version.ref = "compose-jetpack" }
 compose-foundation-jetbrains = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-jetbrains" }
-compose-foundation-jetpack = { module = "androidx.compose.foundation:foundation", version.ref = "compose-jetpack" }
+compose-foundation-jetpack = { module = "androidx.compose.foundation:foundation", version.ref = "compose-foundation" }
 compose-ui-util-jetbrains = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "compose-jetbrains" }
-compose-ui-util-jetpack = { module = "androidx.compose.ui:ui-util", version.ref = "compose-jetpack" }
-compose-material = { module = "androidx.compose.material:material", version.ref = "compose-jetpack" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose-jetpack" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-jetpack" }
+compose-ui-util-jetpack = { module = "androidx.compose.ui:ui-util", version.ref = "compose-ui" }
+compose-material = { module = "androidx.compose.material:material", version.ref = "compose-material" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose-ui" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 accompanist-insets = { module = "com.google.accompanist:accompanist-insets", version.ref = "accompanist" }
 accompanist-pager = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }


### PR DESCRIPTION
# Description
Support independent versioning
https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html


# Is this better?
`compose-material` -> `compose-android-material`

`compose-jetpack-material` was not possible.
```kotlin
composeOptions {
    kotlinCompilerExtensionVersion = libs.versions.compose.jetpack.get()
}
```
```
Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
public inline operator fun <K, V> Map<out TypeVariable(K), TypeVariable(V)>.get(key: TypeVariable(K)): TypeVariable(V)? defined in kotlin.collections
public operator fun MatchGroupCollection.get(name: String): MatchGroup? defined in kotlin.text
public operator fun <T : Any> NamedDomainObjectCollection<TypeVariable(T)>.get(name: String): TypeVariable(T) defined in org.gradle.kotlin.dsl
public operator fun ExtensionContainer.get(name: String): Any defined in org.gradle.kotlin.dsl
public inline fun <S : Any, T : SoftwareComponent> BinaryCollection<TypeVariable(T)>.get(type: KClass<TypeVariable(S)>, spec: Spec<in TypeVariable(S)>): BinaryProvider<TypeVariable(S)> defined in org.gradle.kotlin.dsl
```