### PR TITLE
Fix translation reset after restored

### DIFF
--- a/zoomable/src/commonMain/kotlin/com/mxalbert/zoomable/ZoomableState.kt
+++ b/zoomable/src/commonMain/kotlin/com/mxalbert/zoomable/ZoomableState.kt
@@ -189,6 +189,7 @@ class ZoomableState(
         }
 
     private fun updateBounds() {
+        if (childSize == Size.Zero) return
         val offsetX = childSize.width * scale - size.width
         val offsetY = childSize.height * scale - size.height
         boundOffset = IntOffset((offsetX / 2f).roundToInt(), (offsetY / 2f).roundToInt())

--- a/zoomable/src/commonMain/kotlin/com/mxalbert/zoomable/ZoomableState.kt
+++ b/zoomable/src/commonMain/kotlin/com/mxalbert/zoomable/ZoomableState.kt
@@ -189,6 +189,9 @@ class ZoomableState(
         }
 
     private fun updateBounds() {
+        // If the child is an asynchronously loaded image, its size will be temporarily zero after
+        // the translation values are restored. In that case we don't update the bounds to avoid
+        // resetting the translation values.
         if (childSize == Size.Zero) return
         val offsetX = childSize.width * scale - size.width
         val offsetY = childSize.height * scale - size.height

--- a/zoomable/src/jvmTest/kotlin/com/mxalbert/zoomable/ZoomableTest.kt
+++ b/zoomable/src/jvmTest/kotlin/com/mxalbert/zoomable/ZoomableTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.generateDecayAnimationSpec
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.anyChangeConsumed
@@ -39,6 +40,20 @@ class ZoomableTest {
             initialTranslationY = 100f
         )
         assertThat(state.scale).isEqualTo(2f)
+        assertThat(state.translationX).isEqualTo(100f)
+        assertThat(state.translationY).isEqualTo(100f)
+    }
+
+    @Test
+    fun `Translation not reset after stored`() {
+        val state = ZoomableState(
+            decayAnimationSpec,
+            initialScale = 2f,
+            initialTranslationX = 100f,
+            initialTranslationY = 100f
+        )
+        state.size = IntSize(200, 200)
+        state.childSize = Size(0f, 0f)
         assertThat(state.translationX).isEqualTo(100f)
         assertThat(state.translationY).isEqualTo(100f)
     }


### PR DESCRIPTION
Originated from #22. Fixes #21.